### PR TITLE
Obscure sensible values on .env 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,6 @@ TWILIO_PHONE_NUMBER=
 
 APP_ENV=local
 APP_KEY=
-APP_DEBUG=true
+APP_DEBUG=false
 APP_LOG_LEVEL=debug
 APP_URL=http://localhost

--- a/README.md
+++ b/README.md
@@ -20,57 +20,57 @@
 
 1. First clone this repository and `cd` into it.
 
-   ```
-   $ git clone git@github.com:TwilioDevEd/blog-tfa-laravel.git
-   $ cd blog-tfa-laravel
+   ```bash
+   git clone git@github.com:TwilioDevEd/blog-tfa-laravel.git
+   cd blog-tfa-laravel
    ```
 
 1. Copy the sample configuration file and edit it to match your configuration.
 
-  ```bash
-  $ cp .env.example .env
-  ```
+    ```bash
+    cp .env.example .env
+    ```
 
- You can find your `TWILIO_ACCOUNT_SID` and `TWILIO_AUTH_TOKEN` in your
- [Twilio Account Settings](https://www.twilio.com/user/account/settings).
- You will also need a `TWILIO_NUMBER`, which you may find [here](https://www.twilio.com/user/account/phone-numbers/incoming).
+    You can find your `TWILIO_ACCOUNT_SID` and `TWILIO_AUTH_TOKEN` in your
+    [Twilio Account Settings](https://www.twilio.com/user/account/settings).
+    You will also need a `TWILIO_NUMBER`, which you may find [here](https://www.twilio.com/user/account/phone-numbers/incoming).
 
 1. Install dependencies.
 
-  ```bash
-  $ composer install
-  ```
+    ```bash
+    composer install
+    ```
 
 1. Create the sqlite database.
 
-  ```bash
-  $ php TouchDatabase.php
-  ```
+    ```bash
+    php TouchDatabase.php
+    ```
 
 1. Generate an APP_KEY.
 
-  ```bash
-  $ php artisan key:generate
-  ```
+    ```bash
+    php artisan key:generate
+    ```
 
 1. Run the migrations.
 
-  ```bash
-  $ php artisan migrate
-  $ DB_CONNECTION=sqlite_test php artisan migrate
-  ```
+   ```bash
+   php artisan migrate
+   DB_CONNECTION=sqlite_test php artisan migrate
+   ```
 
 1. Make sure the tests succeed.
 
-  ```bash
-  $ ./vendor/bin/phpunit
-  ```
+   ```bash
+   ./vendor/bin/phpunit
+   ```
 
 1. Run the application.
 
-  ```bash
-  $ php artisan serve
-  ```
+   ```bash
+   php artisan serve
+   ```
 
 ## Meta
 


### PR DESCRIPTION
Changes in the PR:
- Add APP_DEBUG to false
- Improve Readme

Not possible due to the Laravel version:

- `debug_blacklist` to avoid exposing sensible variables even when debug is true. It was added in Laravel 5.5.13, and project version is Laravel 5.2